### PR TITLE
Move to workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,17 @@
-[package]
-name = "bag_of_holding"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package]
+name = "bag_of_holding"
+version.workspace = true
+edition.workspace = true
 
-[dependencies]
+[workspace.dependencies]
 abilities = { path = "./crates/abilities" }
 alignments = { path = "./crates/alignments" }
 anyhow = { version = "1.0.65", features = ["backtrace"] }
@@ -26,8 +32,10 @@ axum-macros = "0.2.3"
 axum-server = { version = "0.4.2", features = ["tls-rustls"] }
 characters = { path = "./crates/characters" }
 clap = { version = "4.0.9", features = ["derive", "env"] }
+damage = { path = "./crates/damage" }
 deities = { path = "./crates/deities" }
 dice = { path = "./crates/dice" }
+enum_dispatch = "0.3.8"
 futures = "0.3.24"
 hyper = { version = "0.14.20", features = ["full"] }
 itertools = "0.10.5"
@@ -36,7 +44,9 @@ metrics-exporter-prometheus = "0.11.0"
 mime = "0.3.16"
 names = { path = "./crates/names" }
 once_cell = "1.15.0"
+races = { path = "./crates/races" }
 rand = "0.8.5"
+rand_pcg = "0.3.1"
 rand_utils = { path = "./crates/rand_utils" }
 sentry = { version = "0.27.0", default-features = false, features = [
     "anyhow",
@@ -53,18 +63,53 @@ sentry-tower = { version = "0.27.0", features = ["http"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 sizes = { path = "./crates/sizes" }
+sources = { path = "./crates/sources" }
+speeds = { path = "./crates/speeds" }
+statrs = "0.16.0"
 strum = { version = "0.24.1", features = ["derive"] }
+thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.4", features = ["full"] }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
-[dev-dependencies]
-statrs = "0.16.0"
+[dependencies]
+abilities.workspace = true
+alignments.workspace = true
+anyhow.workspace = true
+axum.workspace = true
+axum-extra.workspace = true
+axum-macros.workspace = true
+axum-server.workspace = true
+characters.workspace = true
+clap.workspace = true
+deities.workspace = true
+dice.workspace = true
+futures.workspace = true
+hyper.workspace = true
+itertools.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
+mime.workspace = true
+names.workspace = true
+once_cell.workspace = true
+rand.workspace = true
+rand_utils.workspace = true
+sentry.workspace = true
+sentry-tower.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sizes.workspace = true
+strum.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
-[workspace]
-members = ["crates/*"]
+[dev-dependencies]
+statrs.workspace = true
 
 [profile.release]
 lto = "thin"

--- a/crates/abilities/Cargo.toml
+++ b/crates/abilities/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "abilities"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dice = { path = "../dice" }
-itertools = "0.10.5"
-metrics = "0.20.1"
-rand = "0.8.5"
-rand_utils = { path = "../rand_utils" }
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+dice.workspace = true
+itertools.workspace = true
+metrics.workspace = true
+rand.workspace = true
+rand_utils.workspace = true
+serde.workspace = true
+strum.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.85"
-statrs = "0.16.0"
+serde_json.workspace = true
+statrs.workspace = true

--- a/crates/alignments/Cargo.toml
+++ b/crates/alignments/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "alignments"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-itertools = "0.10.5"
-metrics = "0.20.1"
-rand = "0.8.5"
-rand_utils = { path = "../rand_utils" }
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+itertools.workspace = true
+metrics.workspace = true
+rand.workspace = true
+rand_utils.workspace = true
+serde.workspace = true
+strum.workspace = true
+tracing.workspace = true

--- a/crates/characters/Cargo.toml
+++ b/crates/characters/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "characters"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-abilities = { path = "../abilities" }
-alignments = { path = "../alignments" }
-damage = { path = "../damage" }
-metrics = "0.20.1"
-races = { path = "../races" }
-rand = "0.8.5"
-serde = { version = "1.0.145", features = ["derive"] }
-sizes = { path = "../sizes" }
-sources = { path = "../sources" }
-speeds = { path = "../speeds" }
-strum = { version = "0.24.1", features = ["derive"] }
-thiserror = "1.0.37"
-tracing = "0.1.36"
+abilities.workspace = true
+alignments.workspace = true
+damage.workspace = true
+metrics.workspace = true
+races.workspace = true
+rand.workspace = true
+serde.workspace = true
+sizes.workspace = true
+sources.workspace = true
+speeds.workspace = true
+strum.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-rand_utils = { path = "../rand_utils" }
-serde_json = "1.0.85"
+rand_utils.workspace = true
+serde_json.workspace = true

--- a/crates/damage/Cargo.toml
+++ b/crates/damage/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "damage"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+serde.workspace = true
+strum.workspace = true

--- a/crates/deities/Cargo.toml
+++ b/crates/deities/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "deities"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-metrics = "0.20.1"
-rand = "0.8.5"
-rand_utils = { path = "../rand_utils" }
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+metrics.workspace = true
+rand.workspace = true
+rand_utils.workspace = true
+serde.workspace = true
+strum.workspace = true
+tracing.workspace = true

--- a/crates/dice/Cargo.toml
+++ b/crates/dice/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "dice"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-metrics = "0.20.1"
-rand = "0.8.5"
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+metrics.workspace = true
+rand.workspace = true
+serde.workspace = true
+strum.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-itertools = "0.10.5"
-rand_utils = { path = "../rand_utils" }
-statrs = "0.16.0"
+itertools.workspace = true
+rand_utils.workspace = true
+statrs.workspace = true

--- a/crates/names/Cargo.toml
+++ b/crates/names/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "names"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-metrics = "0.20.1"
-rand = "0.8.5"
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+metrics.workspace = true
+rand.workspace = true
+serde.workspace = true
+strum.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-rand_utils = { path = "../rand_utils" }
+rand_utils.workspace = true

--- a/crates/races/Cargo.toml
+++ b/crates/races/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "races"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-damage = { path = "../damage" }
-enum_dispatch = "0.3.8"
-names = { path = "../names" }
-metrics = "0.20.1"
-rand = "0.8.5"
-serde = { version = "1.0.145", features = ["derive"] }
-sizes = { path = "../sizes" }
-sources = { path = "../sources" }
-speeds = { path = "../speeds" }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+damage.workspace = true
+enum_dispatch.workspace = true
+names.workspace = true
+metrics.workspace = true
+rand.workspace = true
+serde.workspace = true
+sizes.workspace = true
+sources.workspace = true
+speeds.workspace = true
+strum.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-itertools = "0.10.5"
-rand_utils = { path = "../rand_utils" }
+itertools.workspace = true
+rand_utils.workspace = true

--- a/crates/rand_utils/Cargo.toml
+++ b/crates/rand_utils/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_utils"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.5"
-tracing = "0.1.36"
-rand_pcg = "0.3.1"
+rand.workspace = true
+rand_pcg.workspace = true
+tracing.workspace = true

--- a/crates/sizes/Cargo.toml
+++ b/crates/sizes/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sizes"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dice = { path = "../dice" }
-rand = "0.8.5"
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.36"
+dice.workspace = true
+rand.workspace = true
+serde.workspace = true
+strum.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-rand_utils = { path = "../rand_utils" }
+rand_utils.workspace = true

--- a/crates/sources/Cargo.toml
+++ b/crates/sources/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sources"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.145", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+serde.workspace = true
+strum.workspace = true

--- a/crates/speeds/Cargo.toml
+++ b/crates/speeds/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "speeds"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.145", features = ["derive"] }
+serde.workspace = true


### PR DESCRIPTION
Move dependencies and package info to workspace inheritance for easier maintenance.